### PR TITLE
String calculator kata

### DIFF
--- a/HaskellKatas.cabal
+++ b/HaskellKatas.cabal
@@ -16,7 +16,9 @@ cabal-version:       >=1.10
 library
   hs-source-dirs:      src
   exposed-modules:     FizzBuzz.FizzBuzz
+                     , StringCalculator.StringCalculator
   build-depends:       base >= 4.7 && < 5
+                     , split
   default-language:    Haskell2010
 
 executable HaskellKatas-exe

--- a/HaskellKatas.cabal
+++ b/HaskellKatas.cabal
@@ -37,6 +37,7 @@ test-suite HaskellKatas-test
                      , HaskellKatas
                      , hspec
                      , QuickCheck
+                     , tuple
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N
   default-language:    Haskell2010
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
-# HaskellKatas [![Build Status](https://travis-ci.org/pedrovgs/HaskellKatas.svg?branch=master)](https://travis-ci.org/pedrovgs/HaskellKatas) 
+# HaskellKatas [![Build Status](https://travis-ci.org/pedrovgs/HaskellKatas.svg?branch=master)](https://travis-ci.org/pedrovgs/HaskellKatas)
 
 Haskell training repository used to learn Haskell and functional programming.
 
 ### List of katas:
 
 * [FizzBuzz](http://codingdojo.org/cgi-bin/index.pl?KataFizzBuzz).
+* [String Calculator](http://osherove.com/tdd-kata-1/)
 
 Developed By
 ------------

--- a/src/StringCalculator/StringCalculator.hs
+++ b/src/StringCalculator/StringCalculator.hs
@@ -1,28 +1,45 @@
 module StringCalculator.StringCalculator
-(add, addWithDelimiter)
+(add)
 where
 
-import Data.List
-import Data.List.Split
+import           Data.Char
+import           Data.List
+import           Data.List.Split
 
 add :: String -> Int
-add = addWithDelimiter '\n'
+add input =
+  if containsCustomDelimiter input then addWithDelimiter (extractDelimiter input) input
+  else addWithDelimiters [",","\n"] input
+
+containsCustomDelimiter :: String -> Bool
+containsCustomDelimiter ""    = False
+containsCustomDelimiter input = "//" `isPrefixOf` input
+
+extractDelimiter :: String -> Char
+extractDelimiter input = head (head (tail ("//" `splitOn` input)))
 
 addWithDelimiter :: Char -> String -> Int
-addWithDelimiter delimiter = addWithDelimiters [delimiter]
+addWithDelimiter delimiter = addWithDelimiters [[delimiter]]
 
-addWithDelimiters :: String -> String -> Int
-addWithDelimiters delimiter input
+addWithDelimiters :: [String] -> String -> Int
+addWithDelimiters delimiters input
     | null input = 0
-    | containsDelimiter delimiter input = sumNumbers delimiter input
+    | containsDelimiter delimiters input = sumNumbers delimiters input
     | otherwise = read input
 
-containsDelimiter :: String -> String -> Bool
-containsDelimiter delimiter input = delimiter `isInfixOf` input
+containsDelimiter :: [String] -> String -> Bool
+containsDelimiter delimiters input = any (`isInfixOf` input) delimiters
 
-sumNumbers :: String -> String -> Int
-sumNumbers delimiter input = sum $ toIntList $ splitOn delimiter input
+sumNumbers :: [String] -> String -> Int
+sumNumbers delimiters input
+    | null delimiters = 0
+    | containsDelimiter [head delimiters] input = sum $ toIntList $ splitOn (head delimiters) input
+    | otherwise = sumNumbers (tail delimiters) input
 
 toIntList :: [String] -> [Int]
-toIntList strings = let filteredList = filter (/= "") strings
-                    in map read filteredList
+toIntList strings = let filteredList = filter isANumber strings
+                    in map (\i -> read i :: Int) filteredList
+
+isANumber :: String -> Bool
+isANumber "" = False
+isANumber value = all isDigit value

--- a/src/StringCalculator/StringCalculator.hs
+++ b/src/StringCalculator/StringCalculator.hs
@@ -9,16 +9,19 @@ add :: String -> Int
 add = addWithDelimiter '\n'
 
 addWithDelimiter :: Char -> String -> Int
-addWithDelimiter delimiter input
+addWithDelimiter delimiter = addWithDelimiters [delimiter]
+
+addWithDelimiters :: String -> String -> Int
+addWithDelimiters delimiter input
     | null input = 0
     | containsDelimiter delimiter input = sumNumbers delimiter input
     | otherwise = read input
 
-containsDelimiter :: Char -> String -> Bool
-containsDelimiter delimiter input = [delimiter] `isInfixOf` input
+containsDelimiter :: String -> String -> Bool
+containsDelimiter delimiter input = delimiter `isInfixOf` input
 
-sumNumbers :: Char -> String -> Int
-sumNumbers delimiter input = sum $ toIntList $ splitOn [delimiter] input
+sumNumbers :: String -> String -> Int
+sumNumbers delimiter input = sum $ toIntList $ splitOn delimiter input
 
 toIntList :: [String] -> [Int]
 toIntList strings = let filteredList = filter (/= "") strings

--- a/src/StringCalculator/StringCalculator.hs
+++ b/src/StringCalculator/StringCalculator.hs
@@ -1,21 +1,25 @@
 module StringCalculator.StringCalculator
-(add)
+(add, addWithDelimiter)
 where
 
 import Data.List
 import Data.List.Split
 
 add :: String -> Int
-add input
+add = addWithDelimiter '\n'
+
+addWithDelimiter :: Char -> String -> Int
+addWithDelimiter delimiter input
     | null input = 0
-    | containsDelimiter input "\n" = sumNumbers "\n" input
+    | containsDelimiter delimiter input = sumNumbers delimiter input
     | otherwise = read input
 
-containsDelimiter :: String -> String -> Bool
-containsDelimiter input delimiter = delimiter `isInfixOf` input
+containsDelimiter :: Char -> String -> Bool
+containsDelimiter delimiter input = [delimiter] `isInfixOf` input
 
-sumNumbers :: String -> String -> Int
-sumNumbers delimiter input = sum $ toIntList $ splitOn delimiter input
+sumNumbers :: Char -> String -> Int
+sumNumbers delimiter input = sum $ toIntList $ splitOn [delimiter] input
 
 toIntList :: [String] -> [Int]
-toIntList = map read
+toIntList strings = let filteredList = filter (/= "") strings
+                    in map read filteredList

--- a/src/StringCalculator/StringCalculator.hs
+++ b/src/StringCalculator/StringCalculator.hs
@@ -1,0 +1,21 @@
+module StringCalculator.StringCalculator
+(add)
+where
+
+import Data.List
+import Data.List.Split
+
+add :: String -> Int
+add input
+    | null input = 0
+    | containsDelimiter input "\n" = sumNumbers "\n" input
+    | otherwise = read input
+
+containsDelimiter :: String -> String -> Bool
+containsDelimiter input delimiter = delimiter `isInfixOf` input
+
+sumNumbers :: String -> String -> Int
+sumNumbers delimiter input = sum $ toIntList $ splitOn delimiter input
+
+toIntList :: [String] -> [Int]
+toIntList = map read

--- a/test/StringCalculator/StringCalculatorSpec.hs
+++ b/test/StringCalculator/StringCalculatorSpec.hs
@@ -1,5 +1,6 @@
 module StringCalculator.StringCalculatorSpec where
 
+import           Data.Char
 import           StringCalculator.StringCalculator
 import           Test.Hspec
 import           Test.QuickCheck
@@ -12,4 +13,40 @@ spec = describe "StringCalculator requirements" $ do
       add "3" `shouldBe` 3
 
     it "returns 5 if the input contains a 2 and a 5 separated by a \n" $
-      add "3\n2" `shouldBe` 5
+      add "3\n2\n" `shouldBe` 5
+
+    it "returns zero or greater than zero if every number is positive" $
+      verboseCheck prop_sumIsAlwaysGreaterThanZeroIfInputContainsPositiveNumbers
+
+prop_sumIsAlwaysGreaterThanZeroIfInputContainsPositiveNumbers :: Property
+prop_sumIsAlwaysGreaterThanZeroIfInputContainsPositiveNumbers =
+  forAll inputWithPositivesAndDelimiters (\input -> uncurry addWithDelimiter input >= 0)
+
+inputWithPositivesAndDelimiters :: Gen (Char, String)
+inputWithPositivesAndDelimiters =
+         do del <- delimiter
+            numberOfItems <- positive
+            positives <- listOfPositives numberOfItems
+            return (del, mixDelimiterAndPositives del positives)
+
+positive :: Gen Int
+positive = abs `fmap` (arbitrary :: Gen Int) `suchThat` (> 0)
+
+listOfPositives :: Int ->  Gen [Int]
+listOfPositives size = vectorOf size positive
+
+delimiter :: Gen Char
+delimiter = suchThat arbitrary (/= ' ')
+
+mixDelimiterAndPositives :: Char -> [Int] -> String
+mixDelimiterAndPositives del positives =
+      let listOfChars = generateListOfChars (length positives) del
+          positivesAsChar = toCharArray positives
+          tuples = zip positivesAsChar listOfChars;
+      in concatMap (\(a,b) -> [a,b]) tuples
+
+generateListOfChars :: Int -> Char -> String
+generateListOfChars numberOfItems del = map (const del) [1..numberOfItems]
+
+toCharArray :: [Int] -> String
+toCharArray numbers = concatMap show numbers

--- a/test/StringCalculator/StringCalculatorSpec.hs
+++ b/test/StringCalculator/StringCalculatorSpec.hs
@@ -12,7 +12,10 @@ spec = describe "StringCalculator requirements" $ do
     it "returns 3 if the input contains just the number 3" $
       add "3" `shouldBe` 3
 
-    it "returns 5 if the input contains a 2 and a 5 separated by a \n" $
+    it "returns 5 if the input contains a 2 and a 5 separated by a '\n'" $
+      add "3\n2\n" `shouldBe` 5
+
+    it "returns 5 if the input contains a 2 and a 5 separated by a ',''" $
       add "3\n2\n" `shouldBe` 5
 
     it "returns zero or greater than zero if every number is positive" $

--- a/test/StringCalculator/StringCalculatorSpec.hs
+++ b/test/StringCalculator/StringCalculatorSpec.hs
@@ -13,11 +13,11 @@ spec = describe "StringCalculator requirements" $ do
     it "returns 3 if the input contains just the number 3" $
       add "3" `shouldBe` 3
 
-    it "returns 5 if the input contains a 2 and a 5 separated by a '\n'" $
+    it "returns 5 if the input contains a 2 and a 5 separated by a '\\n'" $
       add "3\n2\n" `shouldBe` 5
 
     it "returns 5 if the input contains a 2 and a 5 separated by a ',''" $
-      add "3\n2\n" `shouldBe` 5
+      add "3,2," `shouldBe` 5
 
     it "returns zero or greater than zero if every number is positive" $
       property prop_sumIsAlwaysGreaterThanZeroIfInputContainsPositiveNumbers
@@ -27,11 +27,11 @@ spec = describe "StringCalculator requirements" $ do
 
 prop_sumIsAlwaysGreaterThanZeroIfInputContainsPositiveNumbers :: Property
 prop_sumIsAlwaysGreaterThanZeroIfInputContainsPositiveNumbers =
-  forAll inputWithPositivesAndDelimiters (\input -> addWithDelimiter (sel1 input) (sel2 input) >= 0)
+  forAll inputWithPositivesAndDelimiters (\input -> add (sel2 input) >= 0)
 
 prop_sumContainsTheSumOfThePositiveValuesIfInputContainsPositiveNumbers :: Property
 prop_sumContainsTheSumOfThePositiveValuesIfInputContainsPositiveNumbers =
-  forAll inputWithPositivesAndDelimiters (\input -> addWithDelimiter (sel1 input) (sel2 input) == sum (sel3 input))
+  forAll inputWithPositivesAndDelimiters (\input -> add (sel2 input) == sum (sel3 input))
 
 inputWithPositivesAndDelimiters :: Gen (Char, String, [Int])
 inputWithPositivesAndDelimiters =
@@ -54,7 +54,7 @@ mixDelimiterAndPositives del positives =
       let listOfChars = generateListOfChars (length positives) del
           positivesAsChar = toCharArray positives
           tuples = zipWith (\a b -> a ++ [b]) positivesAsChar listOfChars;
-      in concat tuples
+      in "//" ++ [del] ++ concat tuples
 
 generateListOfChars :: Int -> Char -> String
 generateListOfChars numberOfItems del = map (const del) [1..numberOfItems]

--- a/test/StringCalculator/StringCalculatorSpec.hs
+++ b/test/StringCalculator/StringCalculatorSpec.hs
@@ -1,0 +1,15 @@
+module StringCalculator.StringCalculatorSpec where
+
+import           StringCalculator.StringCalculator
+import           Test.Hspec
+import           Test.QuickCheck
+
+spec = describe "StringCalculator requirements" $ do
+    it "returns 0 if the input is empty" $
+      add "" `shouldBe` 0
+
+    it "returns 3 if the input contains just the number 3" $
+      add "3" `shouldBe` 3
+
+    it "returns 5 if the input contains a 2 and a 5 separated by a \n" $
+      add "3\n2" `shouldBe` 5


### PR DESCRIPTION
String Calculator Kata. The second exercise resolved before to start reading [Learn You a Haskell for Great Good!](http://learnyouahaskell.com/).

There are a few interesting points to review in this exercise:

* The usage of the ``tuple`` module for handling tuples of 3 values like ``("a", "b", 3) easily.
* The usage and combination of ``quickcheck`` generators to be able to generate the input needed 
like:
    - Positive integers. ``positive :: Gen Int``
    - Non-empty or digit delimiters. ``delimiter :: Gen Char``
    - A list of positives values with a configured size. ``listOfPositives :: Int ->  Gen [Int]``
    - Tuples. ``inputWithPositivesAndDelimiters :: Gen (Char, String, [Int])``er :: Gen Char``

**The error handling will be implemented in the future once we start working with the ``Maybe`` monad.**