### PR TITLE
Finding the right triangle.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.tag
 *~
 *_flymake.hs
+*.tix
 .hsenv
 .stack-work/
 /.cabal-sandbox/

--- a/HaskellKatas.cabal
+++ b/HaskellKatas.cabal
@@ -17,6 +17,7 @@ library
   hs-source-dirs:      src
   exposed-modules:     FizzBuzz.FizzBuzz
                      , StringCalculator.StringCalculator
+                     , FindingTheRightTriangle.FindingTheRightTriangle
   build-depends:       base >= 4.7 && < 5
                      , split
   default-language:    Haskell2010

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ Haskell training repository used to learn Haskell and functional programming.
 ### List of katas:
 
 * [FizzBuzz](http://codingdojo.org/cgi-bin/index.pl?KataFizzBuzz).
-* [String Calculator](http://osherove.com/tdd-kata-1/)
+* [String calculator](http://osherove.com/tdd-kata-1/)
+* [Finding the right triangle](https://gist.github.com/pedrovgs/32189838165fbe5c9e773ede534b97f4)
 
 ### Executing tests:
 

--- a/src/FindingTheRightTriangle/FindingTheRightTriangle.hs
+++ b/src/FindingTheRightTriangle/FindingTheRightTriangle.hs
@@ -1,0 +1,4 @@
+module FindingTheRightTriangle.FindingTheRightTriangle where
+
+findRightTriangles :: [(Int, Int, Int)]
+findRightTriangles = undefined

--- a/src/FindingTheRightTriangle/FindingTheRightTriangle.hs
+++ b/src/FindingTheRightTriangle/FindingTheRightTriangle.hs
@@ -1,4 +1,6 @@
 module FindingTheRightTriangle.FindingTheRightTriangle where
 
 findRightTriangles :: [(Int, Int, Int)]
-findRightTriangles = undefined
+findRightTriangles = [(a, b, c)
+                      | c <- [1..10], a <- [1..c] , b <- [1..a]
+                      , a^2 + b^2 == c^2, (a + b + c) == 24]

--- a/test/FindingTheRightTriangle/FindingTheRightTriangleSpec.hs
+++ b/test/FindingTheRightTriangle/FindingTheRightTriangleSpec.hs
@@ -1,0 +1,12 @@
+module FindingTheRightTriangle.FindingTheRightTriangleSpec where
+
+import           FindingTheRightTriangle.FindingTheRightTriangle
+import           Test.Hspec
+
+spec = describe "FindingTheRightTriangle requirements" $ do
+  it "every side of each triangle is less than or equal to 10" $
+    all (\(a,b,c) -> a <= 10 && b <= 10 && c <= 10) findRightTriangles
+  it "the perimeter of every triangle is equal to 24" $
+    all (\(a,b,c) -> (a + b + c) == 24) findRightTriangles
+  it "every triangle is a right triangle" $
+    all (\(a,b,c) -> a^2 + b^2 == c^2) findRightTriangles


### PR DESCRIPTION
Review how using list comprehension we can generate a combination of int values, filter the full set based on a list of properties and then map the result into a tuple.

```haskell
findRightTriangles :: [(Int, Int, Int)]
findRightTriangles = [(a, b, c)
                      | c <- [1..10], a <- [1..c] , b <- [1..a]
                      , a^2 + b^2 == c^2, (a + b + c) == 24]
```

If you review the previous func definition the line:

```haskell
| c <- [1..10], a <- [1..c] , b <- [1..a]
```
generates a list of tuples with the combination of integers [1, 1, 1], [1, 2, 1] and so on.

The line:

```haskell
, a^2 + b^2 == c^2, (a + b + c) == 24]
```

declares the filters we have. In this case the Pythagoras Theorem and the perimeter restriction.

The line:

```
findRightTriangles = [(a, b, c)
````

maps the result as a tuple with three values.
