### PR TITLE
Roman numerals

### DIFF
--- a/HaskellKatas.cabal
+++ b/HaskellKatas.cabal
@@ -22,6 +22,7 @@ library
                      , RockPaperScissors.RockPaperScissors
                      , Bingo.Bingo
                      , Potter.Potter
+                     , RomanNumerals.RomanNumerals
   build-depends:       base >= 4.7 && < 5
                      , split
                      , random

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Haskell training repository used to learn Haskell and functional programming.
 * [Rock paper scissors](http://agilekatas.co.uk/katas/RockPaperScissors-Kata).
 * [Bingo](http://agilekatas.co.uk/katas/Bingo-Kata).
 * [Potter](http://www.codingdojo.org/cgi-bin/index.pl?action=browse&id=KataPotter&revision=41).
+* [Roman numerals](http://codingdojo.org/cgi-bin/index.pl?KataRomanNumerals)
 
 
 ### Executing tests:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # HaskellKatas [![Build Status](https://travis-ci.org/pedrovgs/HaskellKatas.svg?branch=master)](https://travis-ci.org/pedrovgs/HaskellKatas)
 
-Haskell training repository used to learn Haskell and functional programming.
+<img alt="Follow me on Twitter" src="https://upload.wikimedia.org/wikipedia/commons/thumb/1/1c/Haskell-Logo.svg/245px-Haskell-Logo.svg.png" height="60" width="82"/>
 
+Haskell training repository used to learn Haskell and functional programming.
 
 ### List of katas:
 
@@ -11,8 +12,12 @@ Haskell training repository used to learn Haskell and functional programming.
 * [Rock paper scissors](http://agilekatas.co.uk/katas/RockPaperScissors-Kata).
 * [Bingo](http://agilekatas.co.uk/katas/Bingo-Kata).
 * [Potter](http://www.codingdojo.org/cgi-bin/index.pl?action=browse&id=KataPotter&revision=41).
-* [Roman numerals](http://codingdojo.org/cgi-bin/index.pl?KataRomanNumerals)
+* [Roman numerals](http://codingdojo.org/cgi-bin/index.pl?KataRomanNumerals).
 
+
+### Development environment:
+
+If you are going to modify the code or just review the implementation from any IDE I strongly recommend you to install [Atom](https://atom.io/) following this [guide](https://github.com/simonmichael/haskell-atom-setup) to set up the whole Haskell environment in a few minutes.
 
 ### Executing tests:
 
@@ -32,10 +37,18 @@ As some of the tests have been developed using [QuickCheck](https://wiki.haskell
 
 Some of our tests and katas work with random values. The Bingo Kata is an example. Remember that you can generate a ``StdGen`` instance from a seed value using ``read "12 33" :: StdGen`` when ``"12 33"`` is the result of ``show mkStdGen 1``.
 
-If you are going to modify the code or just review the implementation from any IDE I strongly recommend you to install [Atom](https://atom.io/) following this [guide](https://github.com/simonmichael/haskell-atom-setup) to set up the whole Haskell environment in a few minutes.
+### Debug logs:
 
+Debug logs are a common way to debug programs. In imperative languages, we can just sprinkle the code with print statements to standard output or to some as log file in order to track debug information (e.g. value of a particular variable, or some human-readable message). In Haskell, however, we cannot output any information other than through the IO monad; and we don't want to introduce that just for debugging. To deal with this problem, the standard library provides the Debug.Trace. That module exports a function called trace which provides a convenient way to attach debug print statements anywhere in a program.
 
-![HaskellLogo](https://upload.wikimedia.org/wikipedia/commons/thumb/1/1c/Haskell-Logo.svg/245px-Haskell-Logo.svg.png)
+You can always add a trace importing the ``Debug.Trace`` module and using the ``trace`` function which receives a ``String`` and a expression ``a -> a`` which will be evaluated as a second param:
+
+```haskell
+fib :: Int -> Int
+fib 0 = 0
+fib 1 = 1
+fib n = trace ("n: " ++ show n) $ fib (n - 1) + fib (n - 2)
+```
 
 Developed By
 ------------

--- a/src/RomanNumerals/RomanNumerals.hs
+++ b/src/RomanNumerals/RomanNumerals.hs
@@ -1,0 +1,1 @@
+module RomanNumerals.RomanNumerals where

--- a/src/RomanNumerals/RomanNumerals.hs
+++ b/src/RomanNumerals/RomanNumerals.hs
@@ -1,21 +1,31 @@
 module RomanNumerals.RomanNumerals
 ( RomanNumeral(..)
-, toRoman)
+, toRoman
+, toArabic)
 where
 
 data RomanNumeral =  I | IV | V | IX | X | L | XC | C | D | CM | M
-  deriving (Enum, Eq, Ord, Bounded, Show)
+  deriving (Enum, Eq, Ord, Bounded, Show, Read)
 
 toRoman :: Int -> String
 toRoman n = toString $ toRomanInner n []
 
--- toArabic
+toArabic :: String -> Int
+toArabic roman = toArabicInner roman 0
 
 toRomanInner :: Int -> [RomanNumeral] -> [RomanNumeral]
 toRomanInner 0 acc = acc
 toRomanInner n acc = toRomanInner (n - closerRomanValue) (acc++[closerRoman])
   where closerRoman = extractCloserRoman n
         closerRomanValue = romanValue closerRoman
+
+toArabicInner :: String -> Int -> Int
+toArabicInner "" acc = acc
+toArabicInner [x] acc = acc + romanValue (stringToRoman (charToString x))
+toArabicInner (x:y:xs) acc
+  | isRomanNumeral combinedRomans = toArabicInner xs (acc + romanValue (read combinedRomans))
+  | otherwise = toArabicInner (y:xs) (acc + romanValue (stringToRoman [x]))
+  where combinedRomans = [x,y]
 
 extractCloserRoman :: Int -> RomanNumeral
 extractCloserRoman n = last $ takeWhile (`canExtract` n) romanNumerals
@@ -27,6 +37,12 @@ romanNumerals :: [RomanNumeral]
 romanNumerals =  [minValue..maxValue]
   where maxValue = maxBound::RomanNumeral
         minValue = minBound::RomanNumeral
+
+stringRomanNumerals :: [String]
+stringRomanNumerals = map show romanNumerals
+
+isRomanNumeral :: String -> Bool
+isRomanNumeral r = r `elem` stringRomanNumerals
 
 romanValue :: RomanNumeral -> Int
 romanValue I  = 1
@@ -43,3 +59,9 @@ romanValue M  = 1000
 
 toString :: [RomanNumeral] -> String
 toString = foldr ((++) . show) ""
+
+stringToRoman :: String -> RomanNumeral
+stringToRoman = read
+
+charToString :: Char -> String
+charToString char = filter (/='\'') (show char)

--- a/src/RomanNumerals/RomanNumerals.hs
+++ b/src/RomanNumerals/RomanNumerals.hs
@@ -4,7 +4,7 @@ module RomanNumerals.RomanNumerals
 , toArabic)
 where
 
-data RomanNumeral =  I | IV | V | IX | X | L | XC | C | D | CM | M
+data RomanNumeral =  I | IV | V | IX | X | XL | L | XC | C | CD | D | CM | M
   deriving (Enum, Eq, Ord, Bounded, Show, Read)
 
 toRoman :: Integer -> String
@@ -50,9 +50,11 @@ romanValue IV = 4
 romanValue V  = 5
 romanValue IX = 9
 romanValue X  = 10
+romanValue XL = 40
 romanValue L  = 50
 romanValue XC = 90
 romanValue C  = 100
+romanValue CD  = 400
 romanValue D  = 500
 romanValue CM = 900
 romanValue M  = 1000

--- a/src/RomanNumerals/RomanNumerals.hs
+++ b/src/RomanNumerals/RomanNumerals.hs
@@ -7,19 +7,19 @@ where
 data RomanNumeral =  I | IV | V | IX | X | L | XC | C | D | CM | M
   deriving (Enum, Eq, Ord, Bounded, Show, Read)
 
-toRoman :: Int -> String
+toRoman :: Integer -> String
 toRoman n = toString $ toRomanInner n []
 
-toArabic :: String -> Int
+toArabic :: String -> Integer
 toArabic roman = toArabicInner roman 0
 
-toRomanInner :: Int -> [RomanNumeral] -> [RomanNumeral]
+toRomanInner :: Integer -> [RomanNumeral] -> [RomanNumeral]
 toRomanInner 0 acc = acc
 toRomanInner n acc = toRomanInner (n - closerRomanValue) (acc++[closerRoman])
   where closerRoman = extractCloserRoman n
         closerRomanValue = romanValue closerRoman
 
-toArabicInner :: String -> Int -> Int
+toArabicInner :: String -> Integer -> Integer
 toArabicInner "" acc = acc
 toArabicInner [x] acc = acc + romanValue (stringToRoman (charToString x))
 toArabicInner (x:y:xs) acc
@@ -27,10 +27,10 @@ toArabicInner (x:y:xs) acc
   | otherwise = toArabicInner (y:xs) (acc + romanValue (stringToRoman [x]))
   where combinedRomans = [x,y]
 
-extractCloserRoman :: Int -> RomanNumeral
+extractCloserRoman :: Integer -> RomanNumeral
 extractCloserRoman n = last $ takeWhile (`canExtract` n) romanNumerals
 
-canExtract :: RomanNumeral -> Int -> Bool
+canExtract :: RomanNumeral -> Integer -> Bool
 canExtract roman n = n - romanValue roman >= 0
 
 romanNumerals :: [RomanNumeral]
@@ -44,7 +44,7 @@ stringRomanNumerals = map show romanNumerals
 isRomanNumeral :: String -> Bool
 isRomanNumeral r = r `elem` stringRomanNumerals
 
-romanValue :: RomanNumeral -> Int
+romanValue :: RomanNumeral -> Integer
 romanValue I  = 1
 romanValue IV = 4
 romanValue V  = 5

--- a/src/RomanNumerals/RomanNumerals.hs
+++ b/src/RomanNumerals/RomanNumerals.hs
@@ -1,1 +1,42 @@
-module RomanNumerals.RomanNumerals where
+module RomanNumerals.RomanNumerals
+( RomanNumeral(..)
+, toRoman)
+where
+
+data RomanNumeral =  I | IV | V | IX | X | L | XC | C | D | CM | M
+  deriving (Enum, Eq, Ord, Bounded, Show)
+
+toRoman :: Int -> [RomanNumeral]
+toRoman n = toRomanInner n []
+
+-- toArabic
+
+toRomanInner :: Int -> [RomanNumeral] -> [RomanNumeral]
+toRomanInner 0 acc = acc
+toRomanInner n acc = toRomanInner (n - closerRomanValue) (acc++[closerRoman])
+  where closerRoman = extractCloserRoman n
+        closerRomanValue = romanValue closerRoman
+
+extractCloserRoman :: Int -> RomanNumeral
+extractCloserRoman n = last $ takeWhile (`canExtract` n) romanNumerals
+
+canExtract :: RomanNumeral -> Int -> Bool
+canExtract roman n = n - romanValue roman >= 0
+
+romanNumerals :: [RomanNumeral]
+romanNumerals =  [minValue..maxValue]
+  where maxValue = maxBound::RomanNumeral
+        minValue = minBound::RomanNumeral
+
+romanValue :: RomanNumeral -> Int
+romanValue I  = 1
+romanValue IV = 4
+romanValue V  = 5
+romanValue IX = 9
+romanValue X  = 10
+romanValue L  = 50
+romanValue XC = 90
+romanValue C  = 100
+romanValue D  = 500
+romanValue CM = 900
+romanValue M  = 1000

--- a/src/RomanNumerals/RomanNumerals.hs
+++ b/src/RomanNumerals/RomanNumerals.hs
@@ -6,8 +6,8 @@ where
 data RomanNumeral =  I | IV | V | IX | X | L | XC | C | D | CM | M
   deriving (Enum, Eq, Ord, Bounded, Show)
 
-toRoman :: Int -> [RomanNumeral]
-toRoman n = toRomanInner n []
+toRoman :: Int -> String
+toRoman n = toString $ toRomanInner n []
 
 -- toArabic
 
@@ -40,3 +40,6 @@ romanValue C  = 100
 romanValue D  = 500
 romanValue CM = 900
 romanValue M  = 1000
+
+toString :: [RomanNumeral] -> String
+toString = foldr ((++) . show) ""

--- a/src/Utils/List.hs
+++ b/src/Utils/List.hs
@@ -2,3 +2,7 @@ module Utils.List where
 
 containsAll :: (Eq a) => [a] -> [a] -> Bool
 containsAll l1 l2 = all (`elem` l2) l1
+
+containsOneOrNothing :: (Eq a) => a -> [a] -> Bool
+containsOneOrNothing x list = length filteredList <= 1
+  where filteredList = filter (\i -> x == i) list

--- a/test/RomanNumerals/RomanNumeralsSpec.hs
+++ b/test/RomanNumerals/RomanNumeralsSpec.hs
@@ -5,15 +5,12 @@ import           Test.Hspec
 import           Test.QuickCheck
 
 spec = describe "RomanNumerals requirements" $ do
-  it "translates 1 as I" $
-    toRoman 1 == "I"
-  it "translates 3 as III" $
-    toRoman 3 == "III"
-  it "translates 5 as V" $
-    toRoman 5 == "V"
-  it "translates 0 as empty" $
-    null $ toRoman 0
-  it "translates 100 as C" $
-    toRoman 100 == "C"
-  it "translates 1990 as MCMXC" $
-    toRoman 1990 == "MCMXC"
+  it "translate from arabic to numeral and back to roman should return the same value" $
+    verboseCheck prop_TranslateBackToArabic
+
+prop_TranslateBackToArabic :: Property
+prop_TranslateBackToArabic = forAll numberBetweenZeroAndThreeThousand (\n -> toArabic (toRoman n) == n)
+
+numberBetweenZeroAndThreeThousand :: Gen Int
+numberBetweenZeroAndThreeThousand = do i <- arbitrary
+                                       return (abs i `mod` 3001)

--- a/test/RomanNumerals/RomanNumeralsSpec.hs
+++ b/test/RomanNumerals/RomanNumeralsSpec.hs
@@ -5,5 +5,15 @@ import           Test.Hspec
 import           Test.QuickCheck
 
 spec = describe "RomanNumerals requirements" $ do
-    it "returns 0 if the input is empty" $
-      True == True
+  it "translates 1 as I" $
+    toRoman 1 == [I]
+  it "translates 3 as III" $
+    toRoman 3 == [I,I,I]
+  it "translates 5 as V" $
+    toRoman 5 == [V]
+  it "translates 0 as empty" $
+    null $ toRoman 0
+  it "translates 100 as C" $
+    toRoman 100 == [C]
+  it "translates 1990 as MCMXC" $
+    toRoman 1990 == [M, CM, XC]

--- a/test/RomanNumerals/RomanNumeralsSpec.hs
+++ b/test/RomanNumerals/RomanNumeralsSpec.hs
@@ -3,14 +3,35 @@ module RomanNumerals.RomanNumeralsSpec where
 import           RomanNumerals.RomanNumerals
 import           Test.Hspec
 import           Test.QuickCheck
+import           Utils.List
 
 spec = describe "RomanNumerals requirements" $ do
   it "translate from arabic to numeral and back to roman should return the same value" $
-    verboseCheck prop_TranslateBackToArabic
+    property prop_TranslateBackToArabic
+  it "arabic numbers greater than zero returns non empty strings" $
+    property prop_NonEmptyStrings
+  it "roman numerals V, D or L can never be repeated" $
+    property prop_VDLAreNotRepeated
 
 prop_TranslateBackToArabic :: Property
 prop_TranslateBackToArabic = forAll numberBetweenZeroAndThreeThousand (\n -> toArabic (toRoman n) == n)
 
-numberBetweenZeroAndThreeThousand :: Gen Int
+prop_NonEmptyStrings :: Property
+prop_NonEmptyStrings = forAll nonZeroArabicNumber $ not . null . toRoman
+
+prop_VDLAreNotRepeated :: Property
+prop_VDLAreNotRepeated = forAll numberBetweenZeroAndThreeThousand
+  (\n -> let translation = toRoman n
+      in containsJustOne translation V
+      && containsJustOne translation D
+      && containsJustOne translation L)
+
+numberBetweenZeroAndThreeThousand :: Gen Integer
 numberBetweenZeroAndThreeThousand = do i <- arbitrary
                                        return (abs i `mod` 3001)
+
+nonZeroArabicNumber :: Gen Integer
+nonZeroArabicNumber = suchThat numberBetweenZeroAndThreeThousand (>0)
+
+containsJustOne :: String -> RomanNumeral -> Bool
+containsJustOne string roman = containsOneOrNothing (head $ show roman) string

--- a/test/RomanNumerals/RomanNumeralsSpec.hs
+++ b/test/RomanNumerals/RomanNumeralsSpec.hs
@@ -1,0 +1,9 @@
+module RomanNumerals.RomanNumeralsSpec where
+
+import           RomanNumerals.RomanNumerals
+import           Test.Hspec
+import           Test.QuickCheck
+
+spec = describe "RomanNumerals requirements" $ do
+    it "returns 0 if the input is empty" $
+      True == True

--- a/test/RomanNumerals/RomanNumeralsSpec.hs
+++ b/test/RomanNumerals/RomanNumeralsSpec.hs
@@ -6,14 +6,14 @@ import           Test.QuickCheck
 
 spec = describe "RomanNumerals requirements" $ do
   it "translates 1 as I" $
-    toRoman 1 == [I]
+    toRoman 1 == "I"
   it "translates 3 as III" $
-    toRoman 3 == [I,I,I]
+    toRoman 3 == "III"
   it "translates 5 as V" $
-    toRoman 5 == [V]
+    toRoman 5 == "V"
   it "translates 0 as empty" $
     null $ toRoman 0
   it "translates 100 as C" $
-    toRoman 100 == [C]
+    toRoman 100 == "C"
   it "translates 1990 as MCMXC" $
-    toRoman 1990 == [M, CM, XC]
+    toRoman 1990 == "MCMXC"


### PR DESCRIPTION
This PR contains the solution to the [roman numerals kata](http://codingdojo.org/cgi-bin/index.pl?KataRomanNumerals). There is a bunch of interesting points to review in this PR:

* Pattern matching over lists.
* ``guard`` syntax combined with ``where`` syntax.
* How to use deriving with ``Show`` and ``Read`` type classes.
* How to associate values to a custom data type deriving ``Enum``.
* How to add log traces when needed using Debug.Trace.
* How some unit tests can be replaced with a loop back property and quickcheck. Take a look at [this commit](https://github.com/pedrovgs/HaskellKatas/pull/7/commits/6fd67f4153915fff45936c7c3a2bd274b6027265#diff-c2c1a994f8d03879c7ec7652d2024a0e).

I've also updated the project REAMDE.md file adding information about how to add log traces when needed.